### PR TITLE
Add ExecuteFullEviction which supports either inducing a new full eviction or awaing an existing one

### DIFF
--- a/.github/workflows/dotnet-releaser.yml
+++ b/.github/workflows/dotnet-releaser.yml
@@ -46,9 +46,10 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: |
-          3.1.x
           6.0.x
           7.0.x
+          8.0.x
+        include-prerelease: true
     - name: Build, Test, Pack, Publish
       shell: pwsh
       env:

--- a/.github/workflows/dotnet-releaser.yml
+++ b/.github/workflows/dotnet-releaser.yml
@@ -20,9 +20,10 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: |
-          3.1.x
           6.0.x
           7.0.x
+          8.0.x
+        include-prerelease: true
     - name: Build, Test, Pack, Publish
       shell: bash
       env:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,10 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
-        <IsTrimmable>true</IsTrimmable>
+        <!-- This is a hack because the life is too short to learn MSBuild -->
+        <IsTrimmable Condition="$(TargetFrameworkVersion) == '6.0'">true</IsTrimmable>
+        <IsTrimmable Condition="$(TargetFrameworkVersion) == '7.0'">true</IsTrimmable>
+        <IsTrimmable Condition="$(TargetFrameworkVersion) == '8.0'">true</IsTrimmable>
         <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 

--- a/src/FastCache.Benchmarks/FastCache.Benchmarks.csproj
+++ b/src/FastCache.Benchmarks/FastCache.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/FastCache.Cached/Constants.cs
+++ b/src/FastCache.Cached/Constants.cs
@@ -81,7 +81,7 @@ internal static class Constants
         get
         {
             var delay = (int)QuickListEvictionInterval.TotalMilliseconds;
-            var jitter = GetRandomInt(0, delay * 2);
+            var jitter = GetRandomInt(0, delay / 2);
             return TimeSpan.FromMilliseconds(delay + jitter);
         }
     }

--- a/src/FastCache.Cached/FastCache.Cached.csproj
+++ b/src/FastCache.Cached/FastCache.Cached.csproj
@@ -15,7 +15,7 @@ Credit to Vladimir Sadov for his implementation of NonBlocking.ConcurrentDiction
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 

--- a/src/FastCache.Sandbox/EvictionStress.cs
+++ b/src/FastCache.Sandbox/EvictionStress.cs
@@ -35,10 +35,10 @@ public static class EvictionStress
         // ThreadPool.QueueUserWorkItem(_ => SeedRandomlyExpirable<Uri2>(10));
         // Thread.Sleep(250);
         // CacheManager.QueueFullClear<(uint, string, int, string, char, bool, float), Uri2>();
-        // ThreadPool.QueueUserWorkItem(_ => SeedRandomlyExpirable<Struct>(5));
+        ThreadPool.QueueUserWorkItem(_ => SeedRandomlyExpirable<Struct>(5));
         ThreadPool.QueueUserWorkItem(_ => SeedSequentiallyExpirable<long>());
         // ThreadPool.QueueUserWorkItem(_ => SeedRandomlyExpirable<User>(1));
-        // ThreadPool.QueueUserWorkItem(_ => SeedRandomlyExpirable<bool>(25));
+        ThreadPool.QueueUserWorkItem(_ => SeedRandomlyExpirable<bool>(25));
         // ThreadPool.QueueUserWorkItem(_ => SeedSequentiallyExpirable<Uri2>());
         // ThreadPool.QueueUserWorkItem(_ => SeedIndefinite<Uri2>(10));
 

--- a/src/FastCache.Sandbox/FastCache.Sandbox.csproj
+++ b/src/FastCache.Sandbox/FastCache.Sandbox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>

--- a/tests/FastCache.CachedTests/FastCache.CachedTests.csproj
+++ b/tests/FastCache.CachedTests/FastCache.CachedTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
- Adjust implementation to make it possible to await in-flight eviction or clear
- Drop EOL'ed .NET Core 3.1 target
- Add .NET 8 preview target for tests
- Make main cache store delay in staggered full eviction less aggressive