### PR TITLE
Help compiler with cctor checks in AOT mode

### DIFF
--- a/src/FastCache.Cached/CacheStaticHolder.cs
+++ b/src/FastCache.Cached/CacheStaticHolder.cs
@@ -1,32 +1,6 @@
-using FastCache.Collections;
-using FastCache.Extensions;
-using FastCache.Helpers;
-using FastCache.Services;
 using NonBlocking;
 
 namespace FastCache;
-
-#if NET5_0_OR_GREATER
-#pragma warning disable CA2255 // Static initialization to ensure cctor checks are removed in JITted code
-internal static class CacheStaticHolder
-{
-    [ModuleInitializer]
-    public static void Initialize()
-    {
-        RuntimeHelpers.RunClassConstructor(typeof(Constants).TypeHandle);
-        RuntimeHelpers.RunClassConstructor(typeof(CacheStaticHolder<,>).TypeHandle);
-        RuntimeHelpers.RunClassConstructor(typeof(CacheManager).TypeHandle);
-
-        RuntimeHelpers.RunClassConstructor(typeof(Cached<,>).TypeHandle);
-        RuntimeHelpers.RunClassConstructor(typeof(Cached).TypeHandle);
-        RuntimeHelpers.RunClassConstructor(typeof(CachedExtensions).TypeHandle);
-        RuntimeHelpers.RunClassConstructor(typeof(CachedRange<>).TypeHandle);
-
-        RuntimeHelpers.RunClassConstructor(typeof(TimeUtils).TypeHandle);
-    }
-}
-#pragma warning restore CA2255
-#endif
 
 internal static class CacheStaticHolder<K, V> where K : notnull
 {

--- a/src/FastCache.Cached/Collections/CachedRange.cs
+++ b/src/FastCache.Cached/Collections/CachedRange.cs
@@ -142,15 +142,17 @@ public static partial class CachedRange<V>
 #if NET6_0_OR_GREATER
         else if (keys.TryGetNonEnumeratedCount(out var count) && GetParallelism((uint)count) > 1)
         {
+            var store = CacheStaticHolder<K, V>.Store;
             keys.AsParallel()
-                .ForAll(static key => CacheStaticHolder<K, V>.Store.TryRemove(key, out _));
+                .ForAll(key => store.TryRemove(key, out _));
         }
 #endif
         else
         {
+            var store = CacheStaticHolder<K, V>.Store;
             foreach (var key in keys)
             {
-                CacheStaticHolder<K, V>.Store.TryRemove(key, out _);
+                store.TryRemove(key, out _);
             }
         }
     }

--- a/src/FastCache.Cached/EvictionQuickList.cs
+++ b/src/FastCache.Cached/EvictionQuickList.cs
@@ -247,10 +247,11 @@ internal sealed class EvictionQuickList<K, V> : IDisposable where K : notnull
 
         uint countAfterTrim = currentCount - toRemoveCount;
 
+        var store = CacheStaticHolder<K, V>.Store;
         uint removed = 0;
         for (uint i = countAfterTrim; i < countAfterTrim + toRemoveCount; i++)
         {
-            if (CacheStaticHolder<K, V>.Store.TryRemove(_active[i].Key, out var _))
+            if (store.TryRemove(_active[i].Key, out var _))
             {
                 removed++;
             }


### PR DESCRIPTION
- hoist static holder contents to locals when compiler can't hoist init checks out of loops
- reorder static holder contents' accesses when compiler fails to CSE multiple static init checks
- remove module initializer because it is no longer relevant for JIT and inconsistently regresses numbers for AOT