### PR TITLE
Add FusionCache to comparison

### DIFF
--- a/src/FastCache.Benchmarks/Comparison.cs
+++ b/src/FastCache.Benchmarks/Comparison.cs
@@ -25,7 +25,7 @@ public class Comparison
         .WithExpiration(CacheManager.Core.ExpirationMode.Absolute, TimeSpan.FromMinutes(60)));
 
     private readonly IAppCache _lazyCache = new CachingService();
-    private readonly IFusionCache _fusionCache = new FusionCache(new FusionCacheOptions());
+    private readonly FusionCache _fusionCache = new (new FusionCacheOptions());
 
     [GlobalSetup]
     public void Initialize()

--- a/src/FastCache.Benchmarks/ComparisonAsync.cs
+++ b/src/FastCache.Benchmarks/ComparisonAsync.cs
@@ -1,0 +1,70 @@
+﻿using LazyCache;
+using Microsoft.Extensions.Caching.Memory;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace FastCache.Benchmarks;
+
+[ShortRunJob]
+[MemoryDiagnoser]
+[DisassemblyDiagnoser(maxDepth: 5, exportCombinedDisassemblyReport: true)]
+public class ComparisonAsync
+{
+    [Params("A", "abcd", "long ass string with букви кирилицею AND UPPERCASE")]
+    public string ItemKey = default!;
+    public string ItemValue = "item value";
+
+    private readonly MemoryCache _memoryCache = new(new MemoryCacheOptions());
+
+    private readonly IAppCache _lazyCache = new CachingService();
+    private readonly IFusionCache _fusionCache = new FusionCache(new FusionCacheOptions());
+
+    private readonly TimeSpan _expire = TimeSpan.FromMinutes(60);
+
+    [GlobalSetup]
+    public void Initialize()
+    {
+        Services.CacheManager.SuspendEviction<string, string>();
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<string> GetOrComputeCached()
+    {
+        return await Cached.GetOrCompute(ItemKey, GetString, _expire);
+    }
+
+    [Benchmark]
+    public async Task<string?> GetOrComputeMemoryCache()
+    {
+        return await _memoryCache.GetOrCreateAsync(ItemKey, async factory =>
+        {
+            factory.SetAbsoluteExpiration(_expire);
+            return await GetString(ItemKey);
+        }) ?? Unreachable<string>();
+    }
+
+    [Benchmark]
+    public async Task<string> GetOrComputeLazyCache()
+    {
+        return await _lazyCache.GetOrAddAsync<string>(ItemKey, async factory =>
+        {
+            factory.SetAbsoluteExpiration(_expire);
+            return await GetString(ItemKey);
+        });
+    }
+
+    [Benchmark]
+    public async Task<string> GetOrComputeFusionCache()
+    {
+        return await _fusionCache.GetOrSetAsync<string>(ItemKey, async (context, _) =>
+        {
+            context.Options.SetDuration(_expire);
+            return await GetString(ItemKey);
+        }) ?? Unreachable<string>();
+    }
+
+    private async Task<string> GetString(string key)
+    {
+        await Task.Delay(10);
+        return await Task.FromResult(ItemValue);
+    }
+}

--- a/src/FastCache.Benchmarks/ComparisonAsync.cs
+++ b/src/FastCache.Benchmarks/ComparisonAsync.cs
@@ -16,7 +16,7 @@ public class ComparisonAsync
     private readonly MemoryCache _memoryCache = new(new MemoryCacheOptions());
 
     private readonly IAppCache _lazyCache = new CachingService();
-    private readonly IFusionCache _fusionCache = new FusionCache(new FusionCacheOptions());
+    private readonly FusionCache _fusionCache = new (new FusionCacheOptions());
 
     private readonly TimeSpan _expire = TimeSpan.FromMinutes(60);
 

--- a/src/FastCache.Benchmarks/FastCache.Benchmarks.csproj
+++ b/src/FastCache.Benchmarks/FastCache.Benchmarks.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="LazyCache" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="RangeExtensions" Version="2.1.1" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.23.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
https://github.com/ZiggyCreatures/FusionCache

<details>

<summary>Comparison</summary>

```

BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Windows 11 (10.0.22621.2428/22H2/2022Update/SunValley2)
13th Gen Intel Core i5-13600K, 1 CPU, 20 logical and 14 physical cores
.NET SDK 7.0.402
  [Host]   : .NET 7.0.12 (7.0.1223.47720), X64 RyuJIT AVX2
  ShortRun : .NET 7.0.12 (7.0.1223.47720), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
| Method             | ItemKey              | Mean       | Error      | StdDev    | Ratio | RatioSD | Gen0   | Code Size | Allocated | Alloc Ratio |
|------------------- |--------------------- |-----------:|-----------:|----------:|------:|--------:|-------:|----------:|----------:|------------:|
| **TryGetCached**       | **A**                    |   **8.541 ns** |  **0.5777 ns** | **0.0317 ns** |  **1.00** |    **0.00** |      **-** |     **141 B** |         **-** |          **NA** |
| TryGetMemoryCache  | A                    |  28.267 ns |  0.3863 ns | 0.0212 ns |  3.31 |    0.01 |      - |   1,896 B |         - |          NA |
| TryGetCacheManager | A                    |  60.590 ns |  1.4952 ns | 0.0820 ns |  7.09 |    0.02 |      - |      62 B |         - |          NA |
| TryGetLazyCache    | A                    |  40.557 ns |  1.2653 ns | 0.0694 ns |  4.75 |    0.02 |      - |      95 B |         - |          NA |
| TryGetFusionCache  | A                    |  58.921 ns |  2.5307 ns | 0.1387 ns |  6.90 |    0.04 | 0.0002 |      92 B |      64 B |          NA |
| UpdateCached       | A                    |  20.889 ns |  9.0983 ns | 0.4987 ns |  2.45 |    0.05 | 0.0001 |     506 B |      40 B |          NA |
| UpdateMemoryCache  | A                    |  68.242 ns |  4.6451 ns | 0.2546 ns |  7.99 |    0.01 | 0.0004 |     229 B |     104 B |          NA |
| UpdateCacheManager | A                    | 137.350 ns | 22.5448 ns | 1.2358 ns | 16.08 |    0.17 | 0.0005 |      37 B |     160 B |          NA |
| UpdateLazyCache    | A                    | 156.478 ns | 21.2041 ns | 1.1623 ns | 18.32 |    0.20 | 0.0012 |   2,226 B |     360 B |          NA |
| UpdateFusionCache  | A                    | 267.882 ns | 13.4650 ns | 0.7381 ns | 31.36 |    0.13 | 0.0024 |     327 B |     656 B |          NA |
|                    |                      |            |            |           |       |         |        |           |           |             |
| **TryGetCached**       | **abcd**                 |   **8.621 ns** |  **0.4873 ns** | **0.0267 ns** |  **1.00** |    **0.00** |      **-** |     **141 B** |         **-** |          **NA** |
| TryGetMemoryCache  | abcd                 |  30.198 ns |  0.3419 ns | 0.0187 ns |  3.50 |    0.01 |      - |   1,896 B |         - |          NA |
| TryGetCacheManager | abcd                 |  60.578 ns |  0.9143 ns | 0.0501 ns |  7.03 |    0.02 |      - |      62 B |         - |          NA |
| TryGetLazyCache    | abcd                 |  40.221 ns |  0.4816 ns | 0.0264 ns |  4.67 |    0.01 |      - |      95 B |         - |          NA |
| TryGetFusionCache  | abcd                 |  61.231 ns | 29.7042 ns | 1.6282 ns |  7.10 |    0.21 | 0.0002 |      92 B |      64 B |          NA |
| UpdateCached       | abcd                 |  20.624 ns |  3.2955 ns | 0.1806 ns |  2.39 |    0.02 | 0.0001 |     506 B |      40 B |          NA |
| UpdateMemoryCache  | abcd                 |  70.094 ns |  5.0711 ns | 0.2780 ns |  8.13 |    0.03 | 0.0004 |     229 B |     104 B |          NA |
| UpdateCacheManager | abcd                 | 138.213 ns | 18.9651 ns | 1.0395 ns | 16.03 |    0.17 | 0.0005 |      37 B |     160 B |          NA |
| UpdateLazyCache    | abcd                 | 157.836 ns | 43.0848 ns | 2.3616 ns | 18.31 |    0.32 | 0.0012 |   2,226 B |     360 B |          NA |
| UpdateFusionCache  | abcd                 | 269.868 ns | 27.5167 ns | 1.5083 ns | 31.30 |    0.26 | 0.0024 |     327 B |     656 B |          NA |
|                    |                      |            |            |           |       |         |        |           |           |             |
| **TryGetCached**       | **long (...)RCASE [50]** |  **26.963 ns** |  **0.1075 ns** | **0.0059 ns** |  **1.00** |    **0.00** |      **-** |     **141 B** |         **-** |          **NA** |
| TryGetMemoryCache  | long (...)RCASE [50] |  53.277 ns |  1.1908 ns | 0.0653 ns |  1.98 |    0.00 |      - |   1,896 B |         - |          NA |
| TryGetCacheManager | long (...)RCASE [50] |  84.099 ns |  3.1708 ns | 0.1738 ns |  3.12 |    0.01 |      - |      62 B |         - |          NA |
| TryGetLazyCache    | long (...)RCASE [50] |  61.557 ns |  0.3860 ns | 0.0212 ns |  2.28 |    0.00 |      - |      95 B |         - |          NA |
| TryGetFusionCache  | long (...)RCASE [50] |  77.815 ns |  2.0818 ns | 0.1141 ns |  2.89 |    0.00 | 0.0002 |      92 B |      64 B |          NA |
| UpdateCached       | long (...)RCASE [50] |  40.289 ns |  2.3702 ns | 0.1299 ns |  1.49 |    0.00 | 0.0001 |     506 B |      40 B |          NA |
| UpdateMemoryCache  | long (...)RCASE [50] | 109.242 ns |  4.4922 ns | 0.2462 ns |  4.05 |    0.01 | 0.0004 |     229 B |     104 B |          NA |
| UpdateCacheManager | long (...)RCASE [50] | 156.429 ns | 18.4198 ns | 1.0097 ns |  5.80 |    0.04 | 0.0005 |      37 B |     160 B |          NA |
| UpdateLazyCache    | long (...)RCASE [50] | 198.177 ns | 37.1873 ns | 2.0384 ns |  7.35 |    0.08 | 0.0012 |   2,226 B |     360 B |          NA |
| UpdateFusionCache  | long (...)RCASE [50] | 309.190 ns | 28.7954 ns | 1.5784 ns | 11.47 |    0.06 | 0.0024 |     327 B |     656 B |          NA |


</details>

<details>

<summary>ComparisonAsync</summary>

```

BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Windows 11 (10.0.22621.2428/22H2/2022Update/SunValley2)
13th Gen Intel Core i5-13600K, 1 CPU, 20 logical and 14 physical cores
.NET SDK 7.0.402
  [Host]   : .NET 7.0.12 (7.0.1223.47720), X64 RyuJIT AVX2
  ShortRun : .NET 7.0.12 (7.0.1223.47720), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
| Method                  | ItemKey              | Mean      | Error     | StdDev   | Ratio | RatioSD | Code Size | Gen0   | Allocated | Alloc Ratio |
|------------------------ |--------------------- |----------:|----------:|---------:|------:|--------:|----------:|-------:|----------:|------------:|
| **GetOrComputeCached**      | **A**                    |  **48.60 ns** |  **4.042 ns** | **0.222 ns** |  **1.00** |    **0.00** |   **7,655 B** | **0.0005** |     **136 B** |        **1.00** |
| GetOrComputeMemoryCache | A                    |  65.70 ns |  8.904 ns | 0.488 ns |  1.35 |    0.01 |   7,672 B | 0.0007 |     208 B |        1.53 |
| GetOrComputeLazyCache   | A                    | 115.34 ns | 71.457 ns | 3.917 ns |  2.37 |    0.07 |   9,045 B | 0.0011 |     304 B |        2.24 |
| GetOrComputeFusionCache | A                    | 144.04 ns |  5.227 ns | 0.286 ns |  2.96 |    0.01 |   9,099 B | 0.0007 |     240 B |        1.76 |
|                         |                      |           |           |          |       |         |           |        |           |             |
| **GetOrComputeCached**      | **abcd**                 |  **48.86 ns** | **16.317 ns** | **0.894 ns** |  **1.00** |    **0.00** |   **7,655 B** | **0.0005** |     **136 B** |        **1.00** |
| GetOrComputeMemoryCache | abcd                 |  66.44 ns | 33.970 ns | 1.862 ns |  1.36 |    0.06 |   7,672 B | 0.0007 |     208 B |        1.53 |
| GetOrComputeLazyCache   | abcd                 | 115.11 ns | 21.979 ns | 1.205 ns |  2.36 |    0.07 |   9,045 B | 0.0011 |     304 B |        2.24 |
| GetOrComputeFusionCache | abcd                 | 146.28 ns | 81.064 ns | 4.443 ns |  3.00 |    0.13 |   9,099 B | 0.0007 |     240 B |        1.76 |
|                         |                      |           |           |          |       |         |           |        |           |             |
| **GetOrComputeCached**      | **long (...)RCASE [50]** |  **64.70 ns** |  **0.936 ns** | **0.051 ns** |  **1.00** |    **0.00** |   **7,655 B** | **0.0005** |     **136 B** |        **1.00** |
| GetOrComputeMemoryCache | long (...)RCASE [50] |  85.35 ns | 24.878 ns | 1.364 ns |  1.32 |    0.02 |   7,672 B | 0.0007 |     208 B |        1.53 |
| GetOrComputeLazyCache   | long (...)RCASE [50] | 159.85 ns | 17.026 ns | 0.933 ns |  2.47 |    0.02 |   9,045 B | 0.0012 |     304 B |        2.24 |
| GetOrComputeFusionCache | long (...)RCASE [50] | 162.33 ns | 29.604 ns | 1.623 ns |  2.51 |    0.03 |   9,099 B | 0.0007 |     240 B |        1.76 |


</details>