### PR TITLE
Drop legacy and EOL targets and update project files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "nuget" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/workflows/dotnet-releaser.yml
+++ b/.github/workflows/dotnet-releaser.yml
@@ -21,9 +21,7 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
-          7.0.x
           8.0.x
-        include-prerelease: true
     - name: Build, Test, Pack, Publish
       shell: bash
       env:
@@ -35,7 +33,7 @@ jobs:
         dotnet tool install -g dotnet-releaser
         dotnet-releaser run --nuget-token "${{secrets.NUGET_TOKEN}}" --github-token "${{secrets.GITHUB_TOKEN}}" dotnet-releaser.toml
 
-  tests-extra-net48:
+  tests-extra-windows:
     runs-on: windows-latest
     steps:
     - name: Checkout
@@ -48,9 +46,7 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
-          7.0.x
           8.0.x
-        include-prerelease: true
     - name: Build, Test, Pack, Publish
       shell: pwsh
       env:

--- a/.github/workflows/dotnet-releaser.yml
+++ b/.github/workflows/dotnet-releaser.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
+          7.0.x
           8.0.x
     - name: Build, Test, Pack, Publish
       shell: bash

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,11 +8,4 @@
         <IsTrimmable>true</IsTrimmable>
         <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="PolySharp" Version="1.13.2">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,14 +1,11 @@
 <Project>
     <PropertyGroup>
-        <Features>strict</Features>
-        <LangVersion>11</LangVersion>
+        <LangVersion>12</LangVersion>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
-        <!-- This is a hack because the life is too short to learn MSBuild -->
-        <IsTrimmable Condition="$(TargetFrameworkVersion) == '6.0'">true</IsTrimmable>
-        <IsTrimmable Condition="$(TargetFrameworkVersion) == '7.0'">true</IsTrimmable>
-        <IsTrimmable Condition="$(TargetFrameworkVersion) == '8.0'">true</IsTrimmable>
+        <IsTrimmable>true</IsTrimmable>
         <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 

--- a/fast-cache.sln
+++ b/fast-cache.sln
@@ -1,5 +1,4 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32427.441
 MinimumVisualStudioVersion = 10.0.40219.1

--- a/src/FastCache.Benchmarks/FastCache.Benchmarks.csproj
+++ b/src/FastCache.Benchmarks/FastCache.Benchmarks.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/FastCache.Cached/CacheManager.cs
+++ b/src/FastCache.Cached/CacheManager.cs
@@ -148,11 +148,8 @@ public static class CacheManager
             return true;
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
         ThreadPool.QueueUserWorkItem(static count => ExecuteTrim(count, takeLock: true), trimCount, preferLocal: true);
-#elif NETSTANDARD2_0
-        ThreadPool.QueueUserWorkItem(static count => ExecuteTrim((uint)count, takeLock: true), trimCount);
-#endif
+
         return false;
     }
 

--- a/src/FastCache.Cached/Collections/CachedRange.cs
+++ b/src/FastCache.Cached/Collections/CachedRange.cs
@@ -102,12 +102,10 @@ public static partial class CachedRange<V>
         {
             Save(genericList, expiration);
         }
-#if NET6_0_OR_GREATER
         else if (range.TryGetNonEnumeratedCount(out var length) && GetParallelism((uint)length) > 1)
         {
             SaveEnumerableMultithreaded(range, expiration);
         }
-#endif
         else
         {
             SaveEnumerableSinglethreaded(range, expiration);
@@ -139,14 +137,12 @@ public static partial class CachedRange<V>
         {
             Remove((ReadOnlyMemory<K>)array);
         }
-#if NET6_0_OR_GREATER
         else if (keys.TryGetNonEnumeratedCount(out var count) && GetParallelism((uint)count) > 1)
         {
             var store = CacheStaticHolder<K, V>.Store;
             keys.AsParallel()
                 .ForAll(key => store.TryRemove(key, out _));
         }
-#endif
         else
         {
             var store = CacheStaticHolder<K, V>.Store;

--- a/src/FastCache.Cached/Constants.cs
+++ b/src/FastCache.Cached/Constants.cs
@@ -17,10 +17,6 @@ internal static class Constants
     private static readonly TimeSpan DefaultQuickListInterval = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan MaxQuickListInterval = TimeSpan.FromSeconds(60);
 
-#if !NET6_0_OR_GREATER
-    private static readonly Random Random = new();
-#endif
-
     public static readonly int QuickListMinLength = (int
         .TryParse(GetVar("FASTCACHE_QUICKLIST_MIN_LENGTH_FACTOR"), out var parsed) ? parsed : DefaultQuickListMinLengthFactor) * 128;
 
@@ -95,13 +91,6 @@ internal static class Constants
 
     private static int GetRandomInt(int minValue, int maxValue)
     {
-#if NET6_0_OR_GREATER
         return Random.Shared.Next(minValue, maxValue);
-#else
-        lock (Random)
-        {
-            return Random.Next(minValue, maxValue);
-        }
-#endif
     }
 }

--- a/src/FastCache.Cached/EvictionJob.cs
+++ b/src/FastCache.Cached/EvictionJob.cs
@@ -55,9 +55,7 @@ internal sealed class EvictionJob<K, V> where K : notnull
             fullEvictionInterval,
             fullEvictionInterval);
 
-#if NETCOREAPP3_0_OR_GREATER
         Gen2GcCallback.Register(() => _ = CacheManager.ExecuteFullEviction<K, V>(triggeredByGC: true));
-#endif
     }
 
     public void ReportExpiration(long milliseconds)

--- a/src/FastCache.Cached/FastCache.Cached.csproj
+++ b/src/FastCache.Cached/FastCache.Cached.csproj
@@ -15,7 +15,6 @@ Credit to Vladimir Sadov for his implementation of NonBlocking.ConcurrentDiction
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
@@ -25,13 +24,6 @@ Credit to Vladimir Sadov for his implementation of NonBlocking.ConcurrentDiction
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NonBlocking" Version="2.1.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FastCache.Cached/Helpers/Extensions.cs
+++ b/src/FastCache.Cached/Helpers/Extensions.cs
@@ -2,16 +2,6 @@ namespace FastCache.Helpers;
 
 internal static class Extensions
 {
-#if NETSTANDARD2_0
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Deconstruct<K, V>(this KeyValuePair<K, V> kvp, out K key, out V value) where K : notnull
-    {
-        key = kvp.Key;
-        value = kvp.Value;
-    }
-#endif
-
-    // These exist for backwards compatibility with netstandard2.0
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static TimeSpan DivideBy(this TimeSpan value, uint divisor)
     {

--- a/src/FastCache.Cached/Helpers/ThrowHelpers.cs
+++ b/src/FastCache.Cached/Helpers/ThrowHelpers.cs
@@ -4,31 +4,19 @@ namespace FastCache.Helpers;
 
 internal static class ThrowHelpers
 {
-#if NETSTANDARD2_0
-    [MethodImpl(MethodImplOptions.NoInlining)]
-#else
     [DoesNotReturn]
-#endif
     public static void ArgumentOutOfRange<T>(T argument, string argumentName)
     {
         throw new ArgumentOutOfRangeException(argumentName, $"Actual value: {argument}");
     }
 
-#if NETSTANDARD2_0
-    [MethodImpl(MethodImplOptions.NoInlining)]
-#else
     [DoesNotReturn]
-#endif
     public static void InvalidExpiration(TimeSpan expiration)
     {
         throw new ArgumentOutOfRangeException(nameof(expiration), expiration, "Expiration must not be negative or zero.");
     }
 
-#if NETSTANDARD2_0
-    [MethodImpl(MethodImplOptions.NoInlining)]
-#else
     [DoesNotReturn]
-#endif
     public static void IncorrectSaveLength(int keys, int values)
     {
         throw new ArgumentOutOfRangeException(nameof(values), values, $"Cannot perform 'Save()' for provided ranges - length mismatch. Expected: {keys}.");

--- a/src/FastCache.Cached/Helpers/TimeUtils.cs
+++ b/src/FastCache.Cached/Helpers/TimeUtils.cs
@@ -2,21 +2,11 @@ namespace FastCache.Helpers;
 
 internal static class TimeUtils
 {
-#if NET6_0_OR_GREATER
     public static long Now
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => Environment.TickCount64;
     }
-#else
-    private static readonly DateTime Offset = DateTime.UtcNow;
-
-    public static long Now
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (DateTime.UtcNow - Offset).Ticks / TimeSpan.TicksPerMillisecond;
-    }
-#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static (long timestamp, long offset) GetTimestamp(TimeSpan expiration)

--- a/src/FastCache.Cached/Helpers/TypeInfo.cs
+++ b/src/FastCache.Cached/Helpers/TypeInfo.cs
@@ -2,11 +2,6 @@ namespace FastCache.Helpers;
 
 internal static class TypeInfo
 {
-    // Will miss nested reference types on netstandard2.0
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if NETSTANDARD2_0
-    public static bool IsManaged<T>() => !typeof(T).IsValueType;
-#else
     public static bool IsManaged<T>() => RuntimeHelpers.IsReferenceOrContainsReferences<T>();
-#endif
 }

--- a/src/FastCache.Sandbox/FastCache.Sandbox.csproj
+++ b/src/FastCache.Sandbox/FastCache.Sandbox.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>

--- a/tests/FastCache.CachedTests/FastCache.CachedTests.csproj
+++ b/tests/FastCache.CachedTests/FastCache.CachedTests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/FastCache.CachedTests/Internals/Helpers.cs
+++ b/tests/FastCache.CachedTests/Internals/Helpers.cs
@@ -23,9 +23,7 @@ public sealed class Helpers
     [Fact]
     public void TypeInfo_IsManaged_ReturnsCorrectValues()
     {
-#if !NETSTANDARD2_0 && !NET48
         Assert.True(TypeInfo.IsManaged<(string, long)>());
-#endif 
         Assert.True(TypeInfo.IsManaged<object>());
 
         Assert.False(TypeInfo.IsManaged<(int, long)>());

--- a/tests/FastCache.CachedTests/TestHelpers.cs
+++ b/tests/FastCache.CachedTests/TestHelpers.cs
@@ -4,8 +4,6 @@ namespace FastCache.Tests;
 
 internal static class TestHelpers
 {
-    private static readonly Random _random = new();
-
     public static string GetTestKey([CallerMemberName] string testName = "")
     {
         return testName;
@@ -23,15 +21,8 @@ internal static class TestHelpers
 
     public static string GetRandomString()
     {
-#if !NETSTANDARD2_0 && !NET48
         var bytes = (stackalloc byte[64]);
-#else
-        var bytes = new byte[64];
-#endif
-        lock (_random)
-        {
-            _random.NextBytes(bytes);
-        }
+        Random.Shared.NextBytes(bytes);
 
         return Convert.ToBase64String(bytes);
     }


### PR DESCRIPTION
This PR removes all TFMs that are older than `net6.0`.

The motivation behind this is that .NET non-framework ecosystem has become sufficiently mature and/or started to offer migration pathways from .NET Framework previously unavailable (e.g. CoreWCF) and supporting older targets like these no longer makes sense.

With that said, a `servicing` branch has been created from the current `main` on the occasion that there are bug reports from the users of the older targets. Should this happen - a servicing package with bugfix backport will be published to support these users.